### PR TITLE
Fix embeded iframes

### DIFF
--- a/src/components/WebView.js
+++ b/src/components/WebView.js
@@ -166,7 +166,6 @@ class WebView extends React.PureComponent {
 
     switch (message.type) {
       case 'navigation':
-        console.log('WebView onMessage', message)
         return this.onNavigationStateChange(message)
       case 'scroll':
         return this.onScrollStateChange(message)

--- a/src/components/WebView.js
+++ b/src/components/WebView.js
@@ -166,6 +166,7 @@ class WebView extends React.PureComponent {
 
     switch (message.type) {
       case 'navigation':
+        console.log('WebView onMessage', message)
         return this.onNavigationStateChange(message)
       case 'scroll':
         return this.onScrollStateChange(message)

--- a/src/utils/webview.js
+++ b/src/utils/webview.js
@@ -36,18 +36,6 @@ export const injectedJavaScriptImpl = function () {
     return back.apply(window.history)
   }
 
-  window.onload = function () {
-    updateNavState()
-  }
-
-  window.onpopstate = function () {
-    updateNavState()
-  }
-
-  window.onhashchange = function () {
-    updateNavState()
-  }
-
   // Scrolling polyfills
 
   function debounce (func, wait) {


### PR DESCRIPTION
Because of the `window.onload` polyfill, the iframe was inferred as a navigation action. However, since now every redirection happens client-side in the app, we don't longer need these polyfills at all. I tested both ios and android apps and they worke exactly the same as expected 