### PR TITLE
Formalize Push Route as a Message

### DIFF
--- a/docs/messages.md
+++ b/docs/messages.md
@@ -140,3 +140,12 @@ Scrolls to the top of the WebView's page
 | Key        | Description           | Value  |
 | ------------- |:-------------:| -----:|
 | type      | Message type | scroll-to-top |
+
+### push-route
+
+Navigate the website to a new url
+
+| Key        | Description           | Value  |
+| ------------- |:-------------:| -----:|
+| type      | Message type | push-route |
+| url | Url | 

--- a/src/components/WebView.js
+++ b/src/components/WebView.js
@@ -130,17 +130,10 @@ class WebView extends React.PureComponent {
     this.webview.ref.reload()
   }
 
-  goBack = () => {
-    if (this.webview.canGoBack) {
-      this.webview.ref.goBack()
-    } else {
-      this.postMessage({ type: 'push-route', url: FEED_PATH })
-    }
-  }
-
   // Native onNavigationStateChange method shim.
   // We call onNavigationStateChange either when the native calls, or onMessage
   onNavigationStateChange = ({ url, canGoBack }) => {
+    debug('onNavigationStateChange', url, canGoBack)
     const { host } = parseUrl(url)
     const { onNavigationStateChange } = this.props
 

--- a/src/components/WebView.js
+++ b/src/components/WebView.js
@@ -110,7 +110,7 @@ class WebView extends React.PureComponent {
       nextProps.source.uri !== this.props.source.uri &&
       nextProps.source.uri !== this.webview.uri
     ) {
-      this.postMessage({ type: 'pushRoute', url: nextUrl.path })
+      this.postMessage({ type: 'push-route', url: nextUrl.path })
     }
   }
 
@@ -134,7 +134,7 @@ class WebView extends React.PureComponent {
     if (this.webview.canGoBack) {
       this.webview.ref.goBack()
     } else {
-      this.postMessage({ type: 'pushRoute', url: FEED_PATH })
+      this.postMessage({ type: 'push-route', url: FEED_PATH })
     }
   }
 

--- a/src/utils/webview.js
+++ b/src/utils/webview.js
@@ -1,7 +1,7 @@
 /* eslint-disable no-undef */
 
 export const injectedJavaScriptImpl = function () {
-  // Navigation polyfills
+  // Navigation spy
   // Injected code to spy on browser's navigation history
   // Native WebView onNavigationStateChange does not recognize SPA page transitions,
   // so we inject code that enables to spy on changes, sending messages.
@@ -29,11 +29,6 @@ export const injectedJavaScriptImpl = function () {
   window.history.replaceState = function () {
     updateNavState(arguments[2])
     return replaceState.apply(window.history, arguments)
-  }
-
-  window.history.back = function () {
-    updateNavState()
-    return back.apply(window.history)
   }
 }
 

--- a/src/utils/webview.js
+++ b/src/utils/webview.js
@@ -35,21 +35,6 @@ export const injectedJavaScriptImpl = function () {
     updateNavState()
     return back.apply(window.history)
   }
-
-  document.addEventListener('message', function (event) {
-    var message = {}
-    try {
-      message = JSON.parse(event.data)
-    } catch (error) {}
-
-    if (message.type === 'scroll-to-top') {
-      window.scrollTo(0, 0)
-    } else if (message.type === 'pushRoute') {
-      window.Router.pushRoute(message.url).then(() => {
-        window.scrollTo(0, 0)
-      })
-    }
-  })
 }
 
 // Implementation IIFE ready to inject


### PR DESCRIPTION
- drop back spy
  - was reporting the current url instead of the url it went back to
  - the web view reports after `window.back` anyhow
