### PR TITLE
Override Firebase methods to prevent Google Play nag alert

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -185,6 +185,7 @@ dependencies {
     implementation "com.google.firebase:firebase-core:15.0.2"
     implementation "com.google.firebase:firebase-messaging:15.0.2"
     implementation 'me.leolin:ShortcutBadger:1.1.21@aar' // <-- Add this line if you wish to use badge on Android
+    implementation 'com.android.support:support-media-compat:27.1.1'
 }
 
 // Run this once to be able to run the application with BUCK

--- a/android/app/src/main/java/app/republik/MainApplication.java
+++ b/android/app/src/main/java/app/republik/MainApplication.java
@@ -13,14 +13,13 @@ import com.guichaguri.trackplayer.TrackPlayer;
 
 // react-native link: react-native-notifications is not used on Android
 
-import com.facebook.react.bridge.ReactApplicationContext;
 import com.learnium.RNDeviceInfo.RNDeviceInfo;
 import com.psykar.cookiemanager.CookieManagerPackage;
-import io.invertase.firebase.RNFirebasePackage;
+
+import app.republik.firebase.NoPlayRNFirebasePackage;
 import io.invertase.firebase.messaging.RNFirebaseMessagingPackage;
 import io.invertase.firebase.notifications.RNFirebaseNotificationsPackage;
 import com.lugg.ReactNativeConfig.ReactNativeConfigPackage;
-import app.republik.BuildConfig;
 
 import org.devio.rn.splashscreen.SplashScreenReactPackage;
 import com.facebook.react.ReactNativeHost;
@@ -28,7 +27,6 @@ import com.facebook.react.ReactPackage;
 import com.facebook.react.shell.MainReactPackage;
 import com.facebook.soloader.SoLoader;
 
-import java.io.File;
 import java.util.Arrays;
 import java.util.List;
 
@@ -56,7 +54,7 @@ public class MainApplication extends Application implements ReactApplication {
           new TrackPlayer(),
           new OTAPackage(),
           new SplashScreenReactPackage(),
-          new RNFirebasePackage(),
+          new NoPlayRNFirebasePackage(),
           new RNDeviceInfo(),
           new CookieManagerPackage(),
           new ReactNativeConfigPackage(),

--- a/android/app/src/main/java/app/republik/firebase/NoPlayRNFirebaseModule.java
+++ b/android/app/src/main/java/app/republik/firebase/NoPlayRNFirebaseModule.java
@@ -1,0 +1,65 @@
+package app.republik.firebase;
+
+import android.app.Activity;
+import android.app.AlertDialog;
+import android.content.DialogInterface;
+import android.content.SharedPreferences;
+import android.preference.PreferenceManager;
+
+import com.facebook.react.bridge.ReactApplicationContext;
+import com.facebook.react.bridge.ReactMethod;
+import com.google.android.gms.common.ConnectionResult;
+import com.google.android.gms.common.GoogleApiAvailability;
+
+/**
+ * This class is introduced to prevent the repeated appearance of a prompt
+ * to install the Google Play Services package if it is missing.
+ */
+public class NoPlayRNFirebaseModule extends io.invertase.firebase.RNFirebaseModule {
+
+    private static final String TAG = "RNFirebase";
+    private static final String NO_PLAY_PREF_KEY = "acceptNoPlayLimitations";
+
+    public NoPlayRNFirebaseModule(ReactApplicationContext reactContext) {
+        super(reactContext);
+    }
+
+    @Override
+    public String getName() {
+        return TAG;
+    }
+
+    @Override
+    @ReactMethod
+    public void promptForPlayServices() {
+        SharedPreferences sharedPreferences =
+                PreferenceManager.getDefaultSharedPreferences(getReactApplicationContext());
+        boolean acceptLimitations = sharedPreferences.getBoolean(NO_PLAY_PREF_KEY, false);
+
+        if (!acceptLimitations) {
+
+            GoogleApiAvailability gapi = GoogleApiAvailability.getInstance();
+            int status = gapi.isGooglePlayServicesAvailable(getReactApplicationContext());
+
+            if (status != ConnectionResult.SUCCESS && gapi.isUserResolvableError(status)) {
+                Activity activity = getCurrentActivity();
+                if (activity != null) {
+                    AlertDialog.Builder builder = new AlertDialog.Builder(activity);
+                    builder.setMessage("Das Paket «Google Play Services» ist auf diesem Gerät nicht installiert. Push-Nachrichten und Login via App funktionieren deshalb nicht.")
+                            .setPositiveButton("OK", new DialogInterface.OnClickListener() {
+                                @Override
+                                public void onClick(DialogInterface dialog, int which) {
+                                    SharedPreferences.Editor editor = sharedPreferences.edit();
+                                    editor.putBoolean(NO_PLAY_PREF_KEY, true);
+                                    editor.apply();
+                                }
+                            })
+                            .show();
+                }
+            }
+
+        }
+
+    }
+
+}

--- a/android/app/src/main/java/app/republik/firebase/NoPlayRNFirebaseModule.java
+++ b/android/app/src/main/java/app/republik/firebase/NoPlayRNFirebaseModule.java
@@ -11,11 +11,13 @@ import com.facebook.react.bridge.ReactMethod;
 import com.google.android.gms.common.ConnectionResult;
 import com.google.android.gms.common.GoogleApiAvailability;
 
+import io.invertase.firebase.RNFirebaseModule;
+
 /**
  * This class is introduced to prevent the repeated appearance of a prompt
  * to install the Google Play Services package if it is missing.
  */
-public class NoPlayRNFirebaseModule extends io.invertase.firebase.RNFirebaseModule {
+public class NoPlayRNFirebaseModule extends RNFirebaseModule {
 
     private static final String TAG = "RNFirebase";
     private static final String NO_PLAY_PREF_KEY = "acceptNoPlayLimitations";

--- a/android/app/src/main/java/app/republik/firebase/NoPlayRNFirebasePackage.java
+++ b/android/app/src/main/java/app/republik/firebase/NoPlayRNFirebasePackage.java
@@ -1,0 +1,26 @@
+package app.republik.firebase;
+
+import com.facebook.react.bridge.NativeModule;
+import com.facebook.react.bridge.ReactApplicationContext;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * This class is needed as a wrapper to instantiate an object of @{@link NoPlayRNFirebaseModule}
+ * instead of @{@link io.invertase.firebase.RNFirebaseModule}
+ */
+@SuppressWarnings("unused")
+public class NoPlayRNFirebasePackage extends io.invertase.firebase.RNFirebasePackage {
+
+  /**
+   * @see @{@link io.invertase.firebase.RNFirebasePackage}
+   */
+  @Override
+  public List<NativeModule> createNativeModules(ReactApplicationContext reactContext) {
+    List<NativeModule> modules = new ArrayList<>();
+    modules.add(new NoPlayRNFirebaseModule(reactContext));
+    return modules;
+  }
+
+}

--- a/android/app/src/main/java/app/republik/firebase/NoPlayRNFirebasePackage.java
+++ b/android/app/src/main/java/app/republik/firebase/NoPlayRNFirebasePackage.java
@@ -6,12 +6,14 @@ import com.facebook.react.bridge.ReactApplicationContext;
 import java.util.ArrayList;
 import java.util.List;
 
+import io.invertase.firebase.RNFirebasePackage;
+
 /**
  * This class is needed as a wrapper to instantiate an object of @{@link NoPlayRNFirebaseModule}
  * instead of @{@link io.invertase.firebase.RNFirebaseModule}
  */
 @SuppressWarnings("unused")
-public class NoPlayRNFirebasePackage extends io.invertase.firebase.RNFirebasePackage {
+public class NoPlayRNFirebasePackage extends RNFirebasePackage {
 
   /**
    * @see @{@link io.invertase.firebase.RNFirebasePackage}

--- a/ios/orbitingapp.xcworkspace/xcshareddata/WorkspaceSettings.xcsettings
+++ b/ios/orbitingapp.xcworkspace/xcshareddata/WorkspaceSettings.xcsettings
@@ -1,8 +1,0 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
-<plist version="1.0">
-<dict>
-	<key>BuildSystemType</key>
-	<string>Original</string>
-</dict>
-</plist>

--- a/ios/orbitingapp.xcworkspace/xcshareddata/WorkspaceSettings.xcsettings
+++ b/ios/orbitingapp.xcworkspace/xcshareddata/WorkspaceSettings.xcsettings
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>BuildSystemType</key>
+	<string>Original</string>
+</dict>
+</plist>


### PR DESCRIPTION
When the app is launched for the first time on an Android phone without Google Play Services a warning is shown.

![screenshot_1542722681](https://user-images.githubusercontent.com/299766/48801873-ccbb8800-ed0d-11e8-841d-cb013cc1fae7.png)

Fixes #163 