### PR TITLE
Fixes Android: no double play and no canOpenUrl

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -151,8 +151,8 @@ android {
         applicationId "app.republik"
         minSdkVersion rootProject.ext.minSdkVersion
         targetSdkVersion rootProject.ext.targetSdkVersion
-        versionCode 186
-        versionName "2.1.2"
+        versionCode 187
+        versionName "2.1.3"
     }
     splits {
         abi {

--- a/ios/republikapp-tvOS/Info.plist
+++ b/ios/republikapp-tvOS/Info.plist
@@ -15,11 +15,11 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>2.1.2</string>
+	<string>2.1.3</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleVersion</key>
-	<string>141</string>
+	<string>142</string>
 	<key>LSRequiresIPhoneOS</key>
 	<true />
 	<key>NSAppTransportSecurity</key>

--- a/ios/republikapp-tvOSTests/Info.plist
+++ b/ios/republikapp-tvOSTests/Info.plist
@@ -15,10 +15,10 @@
 	<key>CFBundlePackageType</key>
 	<string>BNDL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>2.1.2</string>
+	<string>2.1.3</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleVersion</key>
-	<string>141</string>
+	<string>142</string>
 </dict>
 </plist>

--- a/ios/republikapp.xcodeproj/project.pbxproj
+++ b/ios/republikapp.xcodeproj/project.pbxproj
@@ -790,7 +790,7 @@
 				CODE_SIGN_ENTITLEMENTS = republikapp/republikapp.entitlements;
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 141;
+				CURRENT_PROJECT_VERSION = 142;
 				DEVELOPMENT_TEAM = 7MQXM58QM7;
 				ENABLE_BITCODE = NO;
 				"EXCLUDED_ARCHS[sdk=iphonesimulator*]" = arm64;
@@ -866,7 +866,7 @@
 				CODE_SIGN_ENTITLEMENTS = republikapp/republikapp.entitlements;
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 141;
+				CURRENT_PROJECT_VERSION = 142;
 				DEVELOPMENT_TEAM = 7MQXM58QM7;
 				INFOPLIST_FILE = republikapp/Info.plist;
 				IPHONEOS_DEPLOYMENT_TARGET = 10.0;

--- a/ios/republikapp/Info.plist
+++ b/ios/republikapp/Info.plist
@@ -17,7 +17,7 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>2.1.2</string>
+	<string>2.1.3</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleURLTypes</key>
@@ -32,7 +32,7 @@
 		</dict>
 	</array>
 	<key>CFBundleVersion</key>
-	<string>141</string>
+	<string>142</string>
 	<key>ITSAppUsesNonExemptEncryption</key>
 	<false />
 	<key>LSRequiresIPhoneOS</key>

--- a/ios/republikappTests/Info.plist
+++ b/ios/republikappTests/Info.plist
@@ -15,10 +15,10 @@
 	<key>CFBundlePackageType</key>
 	<string>BNDL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>2.1.2</string>
+	<string>2.1.3</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleVersion</key>
-	<string>141</string>
+	<string>142</string>
 </dict>
 </plist>

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "republikapp",
-  "version": "2.1.2",
+  "version": "2.1.3",
   "license": "bsd-3-clause",
   "scripts": {
     "android": "ENVFILE=.env.development react-native run-android",

--- a/patches/react-native-webview+11.3.2.patch
+++ b/patches/react-native-webview+11.3.2.patch
@@ -13,3 +13,22 @@ index e3e878d..cb9964e 100644
      setupWebChromeClient((ReactContext)view.getContext(), view);
    }
  
+diff --git a/node_modules/react-native-webview/lib/WebViewShared.js b/node_modules/react-native-webview/lib/WebViewShared.js
+index 893d48e..612678d 100644
+--- a/node_modules/react-native-webview/lib/WebViewShared.js
++++ b/node_modules/react-native-webview/lib/WebViewShared.js
+@@ -30,13 +30,7 @@ var createOnShouldStartLoadWithRequest = function (loadRequest, originWhitelist,
+         var shouldStart = true;
+         var url = nativeEvent.url, lockIdentifier = nativeEvent.lockIdentifier;
+         if (!passesWhitelist(compileWhitelist(originWhitelist), url)) {
+-            Linking.canOpenURL(url).then(function (supported) {
+-                if (supported) {
+-                    return Linking.openURL(url);
+-                }
+-                console.warn("Can't open url: " + url);
+-                return undefined;
+-            })["catch"](function (e) {
++            Linking.openURL(url)["catch"](function (e) {
+                 console.warn('Error opening URL: ', e);
+             });
+             shouldStart = false;

--- a/src/screens/Web.js
+++ b/src/screens/Web.js
@@ -189,10 +189,10 @@ const Web = () => {
     } else if (message.type === 'haptic') {
       ReactNativeHapticFeedback.trigger(message.payload.type)
     } else if (message.type === 'play-audio') {
+      setGlobalState({ autoPlayAudio: message.payload })
       setPersistedState({
         audio: message.payload,
       })
-      setGlobalState({ autoPlayAudio: true })
     } else if (message.type === 'isSignedIn') {
       setPersistedState({ isSignedIn: message.payload })
     } else if (message.type === 'fullscreen-enter') {


### PR DESCRIPTION
I was able to reproduce the double play issue on Android in my emulator and managed to fix it there.

And I've created a patch to skip `canOpenURL` in the webview. Make sure to re-run `yarn install` or the postinstall script.